### PR TITLE
Run updateBlocklist in a cron job

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,5 @@ require (
 	github.com/jackc/pgx/v4 v4.11.0
 	github.com/joho/godotenv v1.3.0
 	github.com/pkg/errors v0.9.1
+	github.com/robfig/cron v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -342,6 +342,8 @@ github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
+github.com/robfig/cron v1.2.0 h1:ZjScXvvxeQ63Dbyxy76Fj3AT3Ut0aKsyd2/tl3DTMuQ=
+github.com/robfig/cron v1.2.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=

--- a/router.go
+++ b/router.go
@@ -27,9 +27,9 @@ func setupRouter() *gin.Engine {
 	r := gin.Default()
 	r.GET("/v1/addresses/:ipaddress", inBlocklist)
 
-	// Just for testing.
+	// For testing purposes.
 	r.PUT("/addresses", func(c *gin.Context) {
-		if err := updateBlocklist(); err != nil {
+		if err := updateBlocklists(); err != nil {
 			log.Printf("error updating blocklist: %v", err)
 		}
 		c.Status(http.StatusOK)

--- a/update_blocklist.go
+++ b/update_blocklist.go
@@ -10,7 +10,7 @@ import (
 
 const blocklistRepoURL = "https://github.com/firehol/blocklist-ipsets"
 
-func updateBlocklist() error {
+func updateBlocklists() error {
 	if err := cloneBlocklistRepo(); err != nil {
 		return errors.Wrap(err, "error cloning blocklist repo")
 	}


### PR DESCRIPTION
I arbitrarily decided to run the cron job every 25h3m. I thought it is nice to have it a little over 24h, but to be staggered so we are not running it at the same time everyday.

Also I added one comment that I think is worth noting and expanding here as well.

> In some sense adding and updating the blocklists inside this service is like adding state and, instead, this should probably be done in a Lambda or something. The reason being is that if we run a number of replicas they each will try to update the blocklists putting too much pressure on the database.

